### PR TITLE
Fix address created with null addressType or receiverName

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Fixed
+- Address created with either `addressType` or `receiverName` equal to `null`.
 
 ## [0.1.0] - 2020-05-06
 ### Added

--- a/react/ShippingForm.tsx
+++ b/react/ShippingForm.tsx
@@ -27,7 +27,13 @@ const ShippingForm: React.FC = () => {
 
   const handleAddressCreated = useCallback(
     (address: Address) => {
-      send({ type: 'SUBMIT_CREATE_ADDRESS', address })
+      send({
+        type: 'SUBMIT_CREATE_ADDRESS',
+        address: {
+          ...address,
+          addressType: address.addressType ?? 'residential',
+        },
+      })
     },
     [send]
   )
@@ -40,7 +46,14 @@ const ShippingForm: React.FC = () => {
     updatedAddress: Address,
     buyerIsReceiver: boolean
   ) => {
-    send({ type: 'SUBMIT_COMPLETE_ADDRESS', buyerIsReceiver, updatedAddress })
+    send({
+      type: 'SUBMIT_COMPLETE_ADDRESS',
+      buyerIsReceiver,
+      updatedAddress: {
+        ...updatedAddress,
+        addressType: updatedAddress.addressType ?? 'residential',
+      },
+    })
   }
 
   switch (true) {

--- a/react/shippingStateMachine/shippingStateMachine.ts
+++ b/react/shippingStateMachine/shippingStateMachine.ts
@@ -173,7 +173,9 @@ const shippingStateMachine = Machine<
       hasAvailableAddresses: ({ availableAddresses }) =>
         availableAddresses.length !== 0,
       hasIncompleteSelectedAddress: ({ selectedAddress }) =>
-        !!selectedAddress && selectedAddress.addressType == null,
+        !!selectedAddress &&
+        (selectedAddress.addressType == null ||
+          selectedAddress.receiverName == null),
       buyerIsReceiver: (_, event) => {
         if (event.type === 'done.invoke.tryToUpdateCompleteAddress') {
           return event.data.buyerIsReceiver


### PR DESCRIPTION
#### What problem is this solving?

This PR fixes an issue seen while implementing the place order functionality. The API returned that the `addressType` of the address was invalid (because it was `null`), and after fixing it, it caused the `receiverName` to also be invalid because the sub-step that filled the receiver name was being skipped because the address was [flagged as "complete"](https://github.com/vtex-apps/checkout-shipping/blob/c1a325e6ebe66fb4c1c80c542be18d49e9fa9d0b/react/shippingStateMachine/shippingStateMachine.ts#L175-L176).

[Clubhouse story 1](https://app.clubhouse.io/vtex/story/37752/address-type-is-null-after-registering-new-address-in-shipping-step) and [story 2](https://app.clubhouse.io/vtex/story/37753/receiver-name-is-null-after-registering-new-addres-in-shipping-step).

#### How should this be manually tested?

[Workspace](https://lucas--checkoutio.myvtex.com/cart).

Test plan is to fill the shipping form and assert that, after all steps have been completed, the address have a valid `addressType` and `receiverName`.

#### Checklist/Reminders

- [ ] Updated `README.md`.
- [x] Updated `CHANGELOG.md`.
- [x] Linked this PR to a Clubhouse story (if applicable).
- [ ] Updated/created tests (important for bug fixes).
- [ ] Deleted the workspace after merging this PR (if applicable).

#### Type of changes

<!--- Add a ✔️ where applicable -->
✔️ | Type of Change
---|---
✔️ | Bug fix <!-- a non-breaking change which fixes an issue -->
_ | New feature <!-- a non-breaking change which adds functionality -->
_ | Breaking change <!-- fix or feature that would cause existing functionality to change -->
_ | Technical improvements <!-- chores, refactors and overall reduction of technical debt -->