### PR TITLE
CHK-92: Show shipping address on receiver name input screen

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Added
+- Shipping address on receiver name input screen.
 
 ## [0.2.1] - 2020-07-09
 ### Fixed

--- a/react/ShippingForm.tsx
+++ b/react/ShippingForm.tsx
@@ -77,11 +77,14 @@ const ShippingForm: React.FC = () => {
       return (
         state.context.selectedAddress && (
           <ReceiverInfoForm
+            deliveryOptions={state.context.deliveryOptions}
             isSubmitting={matches({ editReceiverInfo: 'submitting' })}
             selectedAddress={state.context.selectedAddress}
+            onEditAddress={() => send('EDIT_ADDRESS')}
             onReceiverInfoSave={receiverName => {
               send({ type: 'SUBMIT_RECEIVER_INFO', receiverName })
             }}
+            onShippingOptionEdit={() => send('GO_TO_SELECT_DELIVERY_OPTION')}
           />
         )
       )

--- a/react/components/ReceiverInfoForm.tsx
+++ b/react/components/ReceiverInfoForm.tsx
@@ -1,22 +1,35 @@
 import React, { useState } from 'react'
-import { Address } from 'vtex.checkout-graphql'
-import { Button, Input } from 'vtex.styleguide'
 import { FormattedMessage, useIntl } from 'react-intl'
+import { Address, DeliveryOption } from 'vtex.checkout-graphql'
+import { Button, ButtonPlain, Divider, IconEdit, Input } from 'vtex.styleguide'
+import { PlaceDetails } from 'vtex.place-components'
+import { FormattedCurrency } from 'vtex.format-currency'
+import { TranslateEstimate } from 'vtex.shipping-estimate-translator'
 
 interface Props {
   isSubmitting: boolean
+  deliveryOptions: DeliveryOption[]
+  onEditAddress: () => void
   onReceiverInfoSave: (receiverName: string) => void
+  onShippingOptionEdit: () => void
   selectedAddress: Address
 }
 
 const ReceiverInfoForm: React.FC<Props> = ({
+  deliveryOptions,
   isSubmitting,
+  onEditAddress,
   onReceiverInfoSave,
+  onShippingOptionEdit,
   selectedAddress,
 }) => {
   const intl = useIntl()
 
   const [name, setName] = useState(selectedAddress.receiverName)
+
+  const selectedDeliveryOption = deliveryOptions.find(
+    ({ isSelected }) => isSelected
+  )
 
   const handleNameChange: React.ChangeEventHandler<HTMLInputElement> = evt => {
     setName(evt.target.value)
@@ -30,33 +43,75 @@ const ReceiverInfoForm: React.FC<Props> = ({
   }
 
   return (
-    <form onSubmit={handleSubmit}>
-      <span className="fw6 dib mb6">
-        <FormattedMessage id="store/checkout.shipping.receiverDescription" />
-      </span>
+    <div className="lh-copy">
+      <div className="c-muted-1">
+        <span className="fw6 flex items-center">
+          <FormattedMessage id="store/checkout.shipping.shippingOptionLabel" />{' '}
+          <div className="dib ml4">
+            <ButtonPlain onClick={onShippingOptionEdit}>
+              <IconEdit solid />
+            </ButtonPlain>
+          </div>
+        </span>
 
-      <div className="mb7">
-        <Input
-          label={intl.formatMessage({
-            id: 'store/checkout.shipping.receiverNameLabel',
-          })}
-          onChange={handleNameChange}
-          value={name}
-        />
+        <div className="mt2 flex flex-column c-muted-1">
+          <span>
+            {selectedDeliveryOption?.id} &ndash;{' '}
+            <FormattedCurrency
+              value={(selectedDeliveryOption?.price ?? 0) / 100}
+            />
+          </span>
+          <span>
+            <TranslateEstimate
+              shippingEstimate={selectedDeliveryOption?.estimate ?? ''}
+            />
+          </span>
+        </div>
       </div>
 
-      <Button
-        type="submit"
-        isLoading={isSubmitting}
-        disabled={isSubmitting}
-        size="large"
-        block
-      >
-        <span className="f5">
-          <FormattedMessage id="store/checkout.shipping.continue" />
+      <div className="mt6 mb5">
+        <Divider />
+      </div>
+
+      <form onSubmit={handleSubmit}>
+        <span className="dib mb4 t-body fw6">
+          <FormattedMessage id="store/checkout.shipping.completeAddressLabel" />{' '}
+          <div className="dib ml4">
+            <ButtonPlain onClick={onEditAddress}>
+              <IconEdit solid />
+            </ButtonPlain>
+          </div>
         </span>
-      </Button>
-    </form>
+
+        <PlaceDetails display="extended" hiddenFields={['receiverName']} />
+
+        <span className="fw6 dib mt7 mb6">
+          <FormattedMessage id="store/checkout.shipping.receiverDescription" />
+        </span>
+
+        <div className="mb7">
+          <Input
+            label={intl.formatMessage({
+              id: 'store/checkout.shipping.receiverNameLabel',
+            })}
+            onChange={handleNameChange}
+            value={name}
+          />
+        </div>
+
+        <Button
+          type="submit"
+          isLoading={isSubmitting}
+          disabled={isSubmitting}
+          size="large"
+          block
+        >
+          <span className="f5">
+            <FormattedMessage id="store/checkout.shipping.continue" />
+          </span>
+        </Button>
+      </form>
+    </div>
   )
 }
 

--- a/react/shippingStateMachine/shippingStateMachine.ts
+++ b/react/shippingStateMachine/shippingStateMachine.ts
@@ -128,6 +128,8 @@ const shippingStateMachine = Machine<
         initial: 'editing',
         on: {
           GO_TO_CREATE_ADDRESS: 'createAddress',
+          GO_TO_SELECT_DELIVERY_OPTION: '#shipping.selectDeliveryOption',
+          EDIT_ADDRESS: '#shipping.completeAddress',
         },
         states: {
           editing: {

--- a/react/shippingStateMachine/typings.d.ts
+++ b/react/shippingStateMachine/typings.d.ts
@@ -21,6 +21,7 @@ export type ShippingMachineEvents =
   | { type: 'GO_TO_CREATE_ADDRESS' }
   | { type: 'GO_TO_SELECT_DELIVERY_OPTION' }
   | { type: 'GO_TO_SELECT_ADDRESS' }
+  | { type: 'EDIT_ADDRESS' }
   | { type: 'RESET_ADDRESS' }
   | { type: 'SUBMIT_SELECT_ADDRESS'; address: Address }
   | {


### PR DESCRIPTION
#### What problem is this solving?

This adds the shipping address to the screen that asks for the receiver name.

#### How should this be manually tested?

1. [Add an item to cart.](https://receiveraddress--checkoutio.myvtex.com/cart/add?sku=289)
2. Use any first-purchase email.
3. In the Shipping step, use `22250-040` as postal code.
4. Select any SLA.
5. Complete the address with any data, uncheck "will receive the order" and continue.
6. On the screen that asks for a receiver name, you should see the shipping address.
7. Click the pencil beside "Shipping option". It should take you to SLA selection.
8. Return to the receiver info screen. Click the pencil beside "Complete de delivery address". It should take you back to the previous screen.

#### Checklist/Reminders

- [ ] Updated `README.md`.
- [x] Updated `CHANGELOG.md`.
- [x] [Linked this PR to a ~Clubhouse~ Jira story (if applicable).](https://vtex-dev.atlassian.net/browse/CHUI-66?atlOrigin=eyJpIjoiYzA4YzdiYWFkMDE0NDFlMzllOGNiZjhkNGNmMmJlYTgiLCJwIjoiaiJ9)
- [ ] Updated/created tests (important for bug fixes).
- [ ] Deleted the workspace after merging this PR (if applicable).

#### Screenshots or example usage
<p align="center"><img src="https://user-images.githubusercontent.com/8902498/86284391-3160e900-bbb9-11ea-96e9-7411c95bd09f.png" width=500></p>
<p align="center"><i>Ignore that "D" at the end of the input.</i></p>

#### Type of changes

<!--- Add a ✔️ where applicable -->
✔️ | Type of Change
---|---
_ | Bug fix <!-- a non-breaking change which fixes an issue -->
_ | New feature <!-- a non-breaking change which adds functionality -->
_ | Breaking change <!-- fix or feature that would cause existing functionality to change -->
_ | Technical improvements <!-- chores, refactors and overall reduction of technical debt -->

