### PR TITLE
Fix address duplication on address completion form.

### DIFF
--- a/react/ShippingForm.tsx
+++ b/react/ShippingForm.tsx
@@ -43,6 +43,7 @@ const ShippingForm: React.FC = () => {
         address: {
           ...address,
           addressType: address.addressType ?? 'residential',
+          addressId: '12345'
         },
       })
     },

--- a/react/ShippingForm.tsx
+++ b/react/ShippingForm.tsx
@@ -43,7 +43,6 @@ const ShippingForm: React.FC = () => {
         address: {
           ...address,
           addressType: address.addressType ?? 'residential',
-          addressId: '12345'
         },
       })
     },

--- a/react/package.json
+++ b/react/package.json
@@ -15,7 +15,7 @@
     "vtex.format-currency": "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.format-currency@0.1.4/public/@types/vtex.format-currency",
     "vtex.formatted-price": "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.formatted-price@0.4.0/public/@types/vtex.formatted-price",
     "vtex.order-manager": "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.order-manager@0.8.5/public/@types/vtex.order-manager",
-    "vtex.order-shipping": "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.order-shipping@0.4.1/public/@types/vtex.order-shipping",
+    "vtex.order-shipping": "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.order-shipping@0.5.0/public/@types/vtex.order-shipping",
     "vtex.place-components": "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.place-components@0.8.1/public/@types/vtex.place-components",
     "vtex.places-graphql": "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.places-graphql@0.2.1/public/@types/vtex.places-graphql",
     "vtex.render-runtime": "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.render-runtime@8.111.0/public/@types/vtex.render-runtime",

--- a/react/shippingStateMachine/useShippingStateMachine.ts
+++ b/react/shippingStateMachine/useShippingStateMachine.ts
@@ -70,6 +70,7 @@ const useShippingStateMachine = ({
     },
     services: {
       tryToEditReceiverInfo: (ctx, { receiverName }) => {
+        console.log(ctx, receiverName);
         return updateSelectedAddress({
           ...ctx.selectedAddress,
           receiverName,

--- a/react/shippingStateMachine/useShippingStateMachine.ts
+++ b/react/shippingStateMachine/useShippingStateMachine.ts
@@ -29,7 +29,6 @@ const useShippingStateMachine = ({
     selectDeliveryOption,
     updateSelectedAddress,
   } = useOrderShipping()
-
   const { setAddress } = useAddressContext()
 
   const { requestLogin } = useCheckoutContainer()
@@ -70,14 +69,20 @@ const useShippingStateMachine = ({
     },
     services: {
       tryToEditReceiverInfo: (ctx, { receiverName }) => {
-        console.log(ctx, receiverName);
         return updateSelectedAddress({
           ...ctx.selectedAddress,
           receiverName,
         })
       },
-      tryToCreateAddress: (_, event) => {
-        return insertAddress(event.address)
+      tryToCreateAddress: async (_, event) => {
+        const res = await insertAddress(event.address)
+        const { success, orderForm } = res;
+
+        if (success && orderForm?.shipping.selectedAddress) {
+          setAddress(orderForm.shipping.selectedAddress)
+        }
+
+        return res
       },
       tryToSelectAddress: (_, event) => {
         return updateSelectedAddress(event.address)

--- a/react/yarn.lock
+++ b/react/yarn.lock
@@ -329,9 +329,9 @@ tslib@^1.10.0, tslib@^1.9.3:
   version "0.8.5"
   resolved "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.order-manager@0.8.5/public/@types/vtex.order-manager#1f01414540d02e2ea7e41e73edaf431d407a9985"
 
-"vtex.order-shipping@http://vtex.vtexassets.com/_v/public/typings/v1/vtex.order-shipping@0.4.1/public/@types/vtex.order-shipping":
-  version "0.4.1"
-  resolved "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.order-shipping@0.4.1/public/@types/vtex.order-shipping#ffe9e705d9e7ff35eec22ccc4d83991e3fd37b78"
+"vtex.order-shipping@http://vtex.vtexassets.com/_v/public/typings/v1/vtex.order-shipping@0.5.0/public/@types/vtex.order-shipping":
+  version "0.5.0"
+  resolved "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.order-shipping@0.5.0/public/@types/vtex.order-shipping#c319f2dfba44177d019373d918b0a5a7160b7aef"
 
 "vtex.place-components@http://vtex.vtexassets.com/_v/public/typings/v1/vtex.place-components@0.8.1/public/@types/vtex.place-components":
   version "0.8.1"


### PR DESCRIPTION
#### What problem is this solving?

The address was being duplicated in address completion form.

#### How should this be manually tested?

[Workspace](https://chk127--checkoutio.myvtex.com/)
Proceed to checkout. Insert a new address. Select delivery option. Complete address information (number, etc). After that, go back to addresses list. There should be only one item of your last registered address.

#### Checklist/Reminders

- [ ] Updated `README.md`.
- [ ] Updated `CHANGELOG.md`.
- [ ] Linked this PR to a Clubhouse story (if applicable).
- [ ] Updated/created tests (important for bug fixes).
- [ ] Deleted the workspace after merging this PR (if applicable).

#### Screenshots or example usage

#### Type of changes

<!--- Add a ✔️ where applicable -->
✔️ | Type of Change
---|---
_ | Bug fix <!-- a non-breaking change which fixes an issue -->
_ | New feature <!-- a non-breaking change which adds functionality -->
_ | Breaking change <!-- fix or feature that would cause existing functionality to change -->
_ | Technical improvements <!-- chores, refactors and overall reduction of technical debt -->

