### PR TITLE
CHK-425: Fix masked address validation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,8 +6,12 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Fixed
+- `ShippingHeader` validating address even if it is masked.
 
 ## [0.4.0] - 2020-11-04
+### Added
+- Components `ShippingHeader`, `ShippingOptionList`, `ShippingOption` and expose `useAddressRules` hook.
 
 ## [0.3.1] - 2020-07-15
 ### Fixed

--- a/react/ShippingHeader.tsx
+++ b/react/ShippingHeader.tsx
@@ -18,11 +18,10 @@ const ShippingHeader: React.VFC<Props> = ({ onEditAddress }) => {
     orderForm: { canEditData },
   } = useOrderForm()
 
-  if (
-    !address ||
-    ((canEditData || address?.isDisposable) &&
-      invalidFields.includes('postalCode'))
-  ) {
+  const isAddressEditable = canEditData || address?.isDisposable
+  const isPostalCodeInvalid = invalidFields.includes('postalCode')
+
+  if (!address || (isAddressEditable && isPostalCodeInvalid)) {
     return (
       <p className="t-body mt0 mb6">
         <FormattedMessage id="store/checkout.shipping.informAddress" />

--- a/react/ShippingHeader.tsx
+++ b/react/ShippingHeader.tsx
@@ -3,17 +3,25 @@ import { ButtonPlain } from 'vtex.styleguide'
 import { PlaceDetails } from 'vtex.place-components'
 import { FormattedMessage } from 'react-intl'
 import { AddressContext } from 'vtex.address-context'
+import { OrderForm } from 'vtex.order-manager'
 
 interface Props {
   onEditAddress?: () => void
 }
 
 const { useAddressContext } = AddressContext
+const { useOrderForm } = OrderForm
 
 const ShippingHeader: React.VFC<Props> = ({ onEditAddress }) => {
   const { address, invalidFields } = useAddressContext()
+  const {
+    orderForm: { canEditData },
+  } = useOrderForm()
 
-  if (!address || invalidFields.includes('postalCode')) {
+  if (
+    (canEditData || address.isDisposable) &&
+    (!address || invalidFields.includes('postalCode'))
+  ) {
     return (
       <p className="t-body mt0 mb6">
         <FormattedMessage id="store/checkout.shipping.informAddress" />

--- a/react/ShippingHeader.tsx
+++ b/react/ShippingHeader.tsx
@@ -19,8 +19,9 @@ const ShippingHeader: React.VFC<Props> = ({ onEditAddress }) => {
   } = useOrderForm()
 
   if (
-    (canEditData || address.isDisposable) &&
-    (!address || invalidFields.includes('postalCode'))
+    !address ||
+    ((canEditData || address?.isDisposable) &&
+      invalidFields.includes('postalCode'))
   ) {
     return (
       <p className="t-body mt0 mb6">


### PR DESCRIPTION
#### What problem is this solving?

Fixes an issue created in the PR #14, where the `ShippingHeader` component would try to validate a masked address (and would mark it as invalid because the asteriscs in the address postal code), so it would show the correct state to the user.

#### How should this be manually tested?

[Workspace](https://lucas--checkoutio.myvtex.com/cart/add?sku=289).

Proceed to checkout and enter a second purchase email, go back to the cart. It should show the postal code on the account correctly, alongside the delivery options.

#### Checklist/Reminders

- [ ] Updated `README.md`.
- [x] Updated `CHANGELOG.md`.
- [x] Linked this PR to a Jira story (if applicable).
- [ ] Updated/created tests (important for bug fixes).
- [ ] Deleted the workspace after merging this PR (if applicable).

#### Screenshots or example usage

#### Type of changes

<!--- Add a ✔️ where applicable -->
✔️ | Type of Change
---|---
✔️ | Bug fix <!-- a non-breaking change which fixes an issue -->
_ | New feature <!-- a non-breaking change which adds functionality -->
_ | Breaking change <!-- fix or feature that would cause existing functionality to change -->
_ | Technical improvements <!-- chores, refactors and overall reduction of technical debt -->

#### Notes

<!-- Put any relevant information that doesn't fit in the other sections here. -->
