### PR TITLE
CHK-138: Use LocationSearch on NewAddressForm based if vtex.geolocation-graphql-interface is used on workspace

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Added
+- Use `LocationSearch` component from `vtex.place-components` on `NewAddressForm` if `vtex.geolocation-graphql-interface` app is used on workspace.
 
 ## [0.4.1] - 2020-11-04
 ### Fixed

--- a/manifest.json
+++ b/manifest.json
@@ -20,7 +20,8 @@
     "vtex.place-components": "0.x",
     "vtex.places-graphql": "0.x",
     "vtex.shipping-estimate-translator": "2.x",
-    "vtex.styleguide": "9.x"
+    "vtex.styleguide": "9.x",
+    "vtex.apps-graphql": "3.x"
   },
   "$schema": "https://raw.githubusercontent.com/vtex/node-vtex-api/master/gen/manifest.schema"
 }

--- a/react/components/NewAddressForm.tsx
+++ b/react/components/NewAddressForm.tsx
@@ -40,7 +40,7 @@ const NewAddressForm: React.FC<Props> = ({ onAddressCreated }) => {
           <LocationInput onSuccess={onAddressCreated} variation="primary" />
         </div>
       ) : (
-        <div className="mt6 w-100 mh3">
+        <div className="mt6 w-100 mw6">
           <LocationSearch onSelectAddress={onAddressCreated} />
         </div>
       )}

--- a/react/components/NewAddressForm.tsx
+++ b/react/components/NewAddressForm.tsx
@@ -1,16 +1,32 @@
 import React, { Fragment } from 'react'
+import { useQuery } from 'react-apollo'
 import {
   DeviceCoordinates,
   LocationInput,
   LocationCountry,
+  LocationSearch,
 } from 'vtex.place-components'
 import { Address } from 'vtex.places-graphql'
+import { Query, QueryInstalledAppArgs } from 'vtex.apps-graphql'
+
+import installedApp from '../graphql/installedApp.gql'
 
 interface Props {
   onAddressCreated: (address: Address) => void
 }
 
 const NewAddressForm: React.FC<Props> = ({ onAddressCreated }) => {
+  const { data, error } = useQuery<Query, QueryInstalledAppArgs>(installedApp, {
+    ssr: false,
+    variables: {
+      slug: 'vtex.geolocation-graphql-interface',
+    },
+  })
+
+  if (error) {
+    console.error(error)
+  }
+
   return (
     <Fragment>
       <div className="pv3">
@@ -19,9 +35,15 @@ const NewAddressForm: React.FC<Props> = ({ onAddressCreated }) => {
       <div className="mt6 w-100 mw6">
         <LocationCountry />
       </div>
-      <div className="mt6 w-100 mw5">
-        <LocationInput onSuccess={onAddressCreated} variation="primary" />
-      </div>
+      {data?.installedApp?.source === 'none' ? (
+        <div className="mt6 w-100 mw5">
+          <LocationInput onSuccess={onAddressCreated} variation="primary" />
+        </div>
+      ) : (
+        <div className="mt6 w-100 mh3">
+          <LocationSearch onSelectAddress={onAddressCreated} />
+        </div>
+      )}
     </Fragment>
   )
 }

--- a/react/graphql/installedApp.gql
+++ b/react/graphql/installedApp.gql
@@ -1,0 +1,5 @@
+query installedApp($slug: String!) {
+  installedApp(slug: $slug) {
+    source
+  }
+}


### PR DESCRIPTION
#### What problem is this solving?

The admin must be able to choose either a postal code (LocationInput) or a free-text autocomplete (LocationSearch) to complete user shipping step.

**For now**, in order to display the LocationSearch component, the admin will have to link the vtex.geolocation-graphql-interface app (together with a resolver and an API key).

#### How should this be manually tested?

- [Workspace](https://w0geo--checkoutio.myvtex.com/cart/add?sku=289)
- Go to shipping step
- Unlink vtex.geolocation-graphql-interface on w0geo workspace and LocationInput should appear
- Link vtex.geolocation-graphql-interface on w0geo workspace and LocationSearch should appear

#### Screenshots or example usage

![image](https://user-images.githubusercontent.com/26108090/98712477-1ff8cc00-2365-11eb-9371-8fc61d3a19da.png)