### PR TITLE
Patch/margin modal

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Fixed
+- Unnecessary top margin when `LocationCountry` component is not rendered.
 
 ## [0.6.1] - 2020-12-07
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,9 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 ### Fixed
 - Unnecessary top margin when `LocationCountry` component is not rendered.
 
+### Changed 
+- `PickupDetailsModal` to use the `Modal` from the `vtex.checkout-components`.
+
 ## [0.6.1] - 2020-12-07
 ### Fixed
 - Border on selected SLAs list.

--- a/react/NewAddressForm.tsx
+++ b/react/NewAddressForm.tsx
@@ -32,9 +32,9 @@ const NewAddressForm: React.FC<Props> = ({ onAddressCreated }) => {
       <div className="pv3">
         <DeviceCoordinates onSuccess={onAddressCreated} />
       </div>
-      <div className="w-100 mw6">
-        <LocationCountry className="mt6" />
-      </div>
+
+      <LocationCountry className="w-100 mw6 mt6" />
+
       {data?.installedApp?.source === 'none' ? (
         <div className="mt6 w-100 mw5">
           <LocationInput onSuccess={onAddressCreated} variation="primary" />

--- a/react/NewAddressForm.tsx
+++ b/react/NewAddressForm.tsx
@@ -32,8 +32,8 @@ const NewAddressForm: React.FC<Props> = ({ onAddressCreated }) => {
       <div className="pv3">
         <DeviceCoordinates onSuccess={onAddressCreated} />
       </div>
-      <div className="mt6 w-100 mw6">
-        <LocationCountry />
+      <div className="w-100 mw6">
+        <LocationCountry className="mt6" />
       </div>
       {data?.installedApp?.source === 'none' ? (
         <div className="mt6 w-100 mw5">

--- a/react/components/PickupDetailsModal.tsx
+++ b/react/components/PickupDetailsModal.tsx
@@ -2,8 +2,9 @@ import React, { useState } from 'react'
 import { TranslateEstimate } from 'vtex.shipping-estimate-translator'
 import { FormattedPrice } from 'vtex.formatted-price'
 import { PickupOption, BusinessHour } from 'vtex.checkout-graphql'
-import { Modal, Divider } from 'vtex.styleguide'
+import { Divider } from 'vtex.styleguide'
 import { PlaceDetails } from 'vtex.place-components'
+import { Modal } from 'vtex.checkout-components'
 import { FormattedMessage, defineMessages, FormattedTime } from 'react-intl'
 
 const messages = defineMessages({

--- a/react/package.json
+++ b/react/package.json
@@ -15,13 +15,13 @@
     "vtex.country-data-settings": "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.country-data-settings@0.3.0/public/@types/vtex.country-data-settings",
     "vtex.format-currency": "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.format-currency@0.2.0/public/@types/vtex.format-currency",
     "vtex.formatted-price": "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.formatted-price@0.4.0/public/@types/vtex.formatted-price",
-    "vtex.order-manager": "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.order-manager@0.8.8/public/@types/vtex.order-manager",
+    "vtex.order-manager": "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.order-manager@0.8.9/public/@types/vtex.order-manager",
     "vtex.order-shipping": "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.order-shipping@0.7.0/public/@types/vtex.order-shipping",
     "vtex.place-components": "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.place-components@0.13.2/public/@types/vtex.place-components",
     "vtex.places-graphql": "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.places-graphql@0.4.0/public/@types/vtex.places-graphql",
-    "vtex.render-runtime": "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.render-runtime@8.126.1/public/@types/vtex.render-runtime",
+    "vtex.render-runtime": "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.render-runtime@8.126.4/public/@types/vtex.render-runtime",
     "vtex.shipping-estimate-translator": "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.shipping-estimate-translator@2.2.2/public/@types/vtex.shipping-estimate-translator",
-    "vtex.styleguide": "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.styleguide@9.133.2/public/@types/vtex.styleguide"
+    "vtex.styleguide": "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.styleguide@9.134.0/public/@types/vtex.styleguide"
   },
   "dependencies": {
     "@vtex/estimate-calculator": "^1.1.0",

--- a/react/package.json
+++ b/react/package.json
@@ -17,7 +17,7 @@
     "vtex.formatted-price": "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.formatted-price@0.4.0/public/@types/vtex.formatted-price",
     "vtex.order-manager": "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.order-manager@0.8.9/public/@types/vtex.order-manager",
     "vtex.order-shipping": "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.order-shipping@0.7.0/public/@types/vtex.order-shipping",
-    "vtex.place-components": "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.place-components@0.13.2/public/@types/vtex.place-components",
+    "vtex.place-components": "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.place-components@0.13.4/public/@types/vtex.place-components",
     "vtex.places-graphql": "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.places-graphql@0.4.0/public/@types/vtex.places-graphql",
     "vtex.render-runtime": "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.render-runtime@8.126.4/public/@types/vtex.render-runtime",
     "vtex.shipping-estimate-translator": "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.shipping-estimate-translator@2.2.2/public/@types/vtex.shipping-estimate-translator",

--- a/react/yarn.lock
+++ b/react/yarn.lock
@@ -350,9 +350,9 @@ tslib@^1.10.0, tslib@^1.9.3:
   version "0.7.0"
   resolved "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.order-shipping@0.7.0/public/@types/vtex.order-shipping#4d020086b9da30807f0b6ec059c30d5a8727889d"
 
-"vtex.place-components@http://vtex.vtexassets.com/_v/public/typings/v1/vtex.place-components@0.13.2/public/@types/vtex.place-components":
-  version "0.13.2"
-  resolved "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.place-components@0.13.2/public/@types/vtex.place-components#a97e5140d855f455d85b71692e60226fea93e603"
+"vtex.place-components@http://vtex.vtexassets.com/_v/public/typings/v1/vtex.place-components@0.13.4/public/@types/vtex.place-components":
+  version "0.13.4"
+  resolved "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.place-components@0.13.4/public/@types/vtex.place-components#80739c510fc232ef76ab66f11f5cefbbf95e63b2"
 
 "vtex.places-graphql@http://vtex.vtexassets.com/_v/public/typings/v1/vtex.places-graphql@0.4.0/public/@types/vtex.places-graphql":
   version "0.4.0"

--- a/react/yarn.lock
+++ b/react/yarn.lock
@@ -342,9 +342,9 @@ tslib@^1.10.0, tslib@^1.9.3:
   version "0.4.0"
   resolved "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.formatted-price@0.4.0/public/@types/vtex.formatted-price#821e3f087065704d02ee28e4f41aada3d6cb46da"
 
-"vtex.order-manager@http://vtex.vtexassets.com/_v/public/typings/v1/vtex.order-manager@0.8.8/public/@types/vtex.order-manager":
-  version "0.8.8"
-  resolved "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.order-manager@0.8.8/public/@types/vtex.order-manager#a84ac706a21afee00afad961670323b8aa3fc3a5"
+"vtex.order-manager@http://vtex.vtexassets.com/_v/public/typings/v1/vtex.order-manager@0.8.9/public/@types/vtex.order-manager":
+  version "0.8.9"
+  resolved "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.order-manager@0.8.9/public/@types/vtex.order-manager#29ae24cac9f4bc58b01abdbf99e608228307c17e"
 
 "vtex.order-shipping@http://vtex.vtexassets.com/_v/public/typings/v1/vtex.order-shipping@0.7.0/public/@types/vtex.order-shipping":
   version "0.7.0"
@@ -358,17 +358,17 @@ tslib@^1.10.0, tslib@^1.9.3:
   version "0.4.0"
   resolved "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.places-graphql@0.4.0/public/@types/vtex.places-graphql#19d8522f344c82c677b474829deb629583def399"
 
-"vtex.render-runtime@http://vtex.vtexassets.com/_v/public/typings/v1/vtex.render-runtime@8.126.1/public/@types/vtex.render-runtime":
-  version "8.126.1"
-  resolved "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.render-runtime@8.126.1/public/@types/vtex.render-runtime#3c1b8e2f331ca7d3eaeda2f09a6509243e8f9e67"
+"vtex.render-runtime@http://vtex.vtexassets.com/_v/public/typings/v1/vtex.render-runtime@8.126.4/public/@types/vtex.render-runtime":
+  version "8.126.4"
+  resolved "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.render-runtime@8.126.4/public/@types/vtex.render-runtime#40d7ad8a7b04c50e61ff84a1089dcf7045efd548"
 
 "vtex.shipping-estimate-translator@http://vtex.vtexassets.com/_v/public/typings/v1/vtex.shipping-estimate-translator@2.2.2/public/@types/vtex.shipping-estimate-translator":
   version "2.2.2"
   resolved "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.shipping-estimate-translator@2.2.2/public/@types/vtex.shipping-estimate-translator#0daa482f261e7c40a06c27be07e9e5b9d70cf063"
 
-"vtex.styleguide@http://vtex.vtexassets.com/_v/public/typings/v1/vtex.styleguide@9.133.2/public/@types/vtex.styleguide":
-  version "9.133.2"
-  resolved "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.styleguide@9.133.2/public/@types/vtex.styleguide#0b2020bfe4732e76f7dc6fcff4a77ba81f211c5d"
+"vtex.styleguide@http://vtex.vtexassets.com/_v/public/typings/v1/vtex.styleguide@9.134.0/public/@types/vtex.styleguide":
+  version "9.134.0"
+  resolved "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.styleguide@9.134.0/public/@types/vtex.styleguide#9ce9062c2a0f9925d7a926a9c4d544b4f0409590"
 
 xstate@^4.8.0:
   version "4.9.1"


### PR DESCRIPTION
#### What problem is this solving?

This PR does two things:

- Removes an unnecessary top margin when the `LocationCountry` component isn't rendered. That way, we no longer have an unwanted space between the current location button and the postal code input.

- Changes the `PickupDetailsModal` to use the `Modal` from the `checkout-components` instead of the one from the `vtex.styleguide`. 

<!--- What is the motivation and context for this change? -->

#### How should this be manually tested?

[Workspace](https://jeff--checkoutio.myvtex.com/cart/add?sku=307)

#### Checklist/Reminders

- [ ] Updated `README.md`.
- [x] Updated `CHANGELOG.md`.
- [ ] Linked this PR to a Jira story (if applicable).
- [ ] Updated/created tests (important for bug fixes).
- [ ] Deleted the workspace after merging this PR (if applicable).

#### Screenshots or example usage

**Before** 

![image](https://user-images.githubusercontent.com/12574426/101439022-630d7700-38f2-11eb-82b1-6846db9fb4bf.png)

![image](https://user-images.githubusercontent.com/12574426/101439318-09597c80-38f3-11eb-9f0a-9073d46d37ab.png)


**After**

![image](https://user-images.githubusercontent.com/12574426/101439049-73bded00-38f2-11eb-913b-92a941756783.png)

![image](https://user-images.githubusercontent.com/12574426/101439380-22fac400-38f3-11eb-9e5a-e3bf81764bbb.png)


#### Type of changes

<!--- Add a ✔️ where applicable -->
✔️ | Type of Change
---|---
_ | Bug fix <!-- a non-breaking change which fixes an issue -->
_ | New feature <!-- a non-breaking change which adds functionality -->
_ | Breaking change <!-- fix or feature that would cause existing functionality to change -->
✔️ | Technical improvements <!-- chores, refactors and overall reduction of technical debt -->
