### PR TITLE
Add ids to the elements in order to choose shipping through e2e tests

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Added
+- `id` to the elements needed in order to make e2e tests.
 
 ## [0.6.2] - 2020-12-11
 ### Fixed

--- a/react/ShippingOption.tsx
+++ b/react/ShippingOption.tsx
@@ -8,7 +8,7 @@ import { IconDelete, ButtonPlain, Modal, Divider } from 'vtex.styleguide'
 import { FormattedMessage } from 'react-intl'
 
 import PickupDetailsModal from './components/PickupDetailsModal'
-import { getName, isPickupOption } from './utils/sla'
+import { getName, isPickupOption, slugify } from './utils/sla'
 
 interface EstimateDeliveryOption {
   shippingEstimate: string
@@ -35,7 +35,7 @@ const ShippingOption: React.VFC<Props> = ({
   const [showPickupModal, setShowPickupModal] = useState(false)
 
   const content = (
-    <div className="flex w-100">
+    <div className="flex w-100" id={slugify(shippingOption.id)}>
       <div className="flex flex-column w-100">
         <span className="c-on-base fw5">{getName(shippingOption)}</span>
         <span

--- a/react/components/AddressCompletionForm.tsx
+++ b/react/components/AddressCompletionForm.tsx
@@ -168,6 +168,7 @@ const AddressCompletionForm: React.FC<Props> = ({
         )}
 
         <Button
+          testId="continue-shipping"
           block
           size="large"
           type="submit"

--- a/react/components/AddressCompletionForm.tsx
+++ b/react/components/AddressCompletionForm.tsx
@@ -168,7 +168,7 @@ const AddressCompletionForm: React.FC<Props> = ({
         )}
 
         <Button
-          testId="continue-shipping"
+          testId="continue-shipping-button"
           block
           size="large"
           type="submit"

--- a/react/utils/sla.ts
+++ b/react/utils/sla.ts
@@ -11,3 +11,7 @@ export const getName = (shippingOption: DeliveryOption | PickupOption) => {
     ? shippingOption.friendlyName
     : shippingOption.id
 }
+
+export const slugify = (text: string) => {
+  return text?.toLowerCase().replace(/\s+/g, '-').replace(/[()]/g, '')
+}


### PR DESCRIPTION
#### What problem is this solving?

This PR adds an id to the `ShippingOption` component and to the "Continue Shipping" button. 

With that, we are now able to test the shipping logic through e2e tests.

<!--- What is the motivation and context for this change? -->

#### How should this be manually tested?

[Workspace](https://pickupe2e--checkoutio.myvtex.com/cart/add?sku=307)

#### Checklist/Reminders

- [ ] Updated `README.md`.
- [x] Updated `CHANGELOG.md`.
- [ ] Linked this PR to a Jira story (if applicable).
- [ ] Updated/created tests (important for bug fixes).
- [ ] Deleted the workspace after merging this PR (if applicable).

#### Type of changes

<!--- Add a ✔️ where applicable -->
✔️ | Type of Change
---|---
_ | Bug fix <!-- a non-breaking change which fixes an issue -->
_ | New feature <!-- a non-breaking change which adds functionality -->
_ | Breaking change <!-- fix or feature that would cause existing functionality to change -->
✔️ | Technical improvements <!-- chores, refactors and overall reduction of technical debt -->
