### PR TITLE
Make default value for addressRules to be undefined

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Fixed
+- Make default value for `addressRules` to be `undefined`.
 
 ## [0.6.4] - 2020-12-17
 

--- a/react/useAddressRules.tsx
+++ b/react/useAddressRules.tsx
@@ -23,7 +23,7 @@ const useAddressRules = () => {
           },
         }),
         {}
-      ) ?? {},
+      ),
     [data]
   )
 


### PR DESCRIPTION
#### What problem is this solving?

If we want to wait for the address rules to load before rendering something, we would need to do a `Object.keys(addressRules).length === 0` check (which is kinda awkward, and probably a more expensive operation), and with these changes we could just compare the value to `null` (using `==`) instead. The motivation for this is for the App Store, which doesn't have a shipping step before the payment (where this is used to show the billing address form), and when the user gets there the address rules query was never executed before (thus, we need to make a request and wait for it to complete before rendering) which was causing an error to be thrown.

I like the comparison with `undefined` or `null` better than the `Object.keys(addressRules).length === 0`, and I think it may perform better (although I haven't benchmarked them, and it probably won't make a difference in this case), but I'd like to hear other opinions if you disagree. One other point I remembered why I prefer this comparison with undefined is that the `addressRules` can actually be an empty object (when the account doesn't have any of the countries data apps installed) and so the component would be stuck in an infinite load.

#### How should this be manually tested?

[Workspace](http://pedrocheckout--extensions.myvtex.com/vtex-sms-provider/p).

You can see it is now working in the above workspace (you can use the account `pilateslovers` when they ask the VTEX Store).

#### Checklist/Reminders

- [ ] Updated `README.md`.
- [x] Updated `CHANGELOG.md`.
- [ ] Linked this PR to a Jira story (if applicable).
- [ ] Updated/created tests (important for bug fixes).
- [ ] Deleted the workspace after merging this PR (if applicable).

#### Screenshots or example usage

#### Type of changes

<!--- Add a ✔️ where applicable -->
✔️ | Type of Change
---|---
✔️ | Bug fix <!-- a non-breaking change which fixes an issue -->
_ | New feature <!-- a non-breaking change which adds functionality -->
_ | Breaking change <!-- fix or feature that would cause existing functionality to change -->
_ | Technical improvements <!-- chores, refactors and overall reduction of technical debt -->
