### PR TITLE
Update to use geolocation hook from checkout-resources

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Changed
+- Updated geolocation condition to use `useGeolocationEnabled` hook from `checkout-resources`.
 
 ## [0.7.1] - 2021-02-19
 ### Changed

--- a/manifest.json
+++ b/manifest.json
@@ -1,7 +1,7 @@
 {
   "vendor": "vtex",
   "name": "checkout-shipping",
-  "version": "0.7.2-beta.0",
+  "version": "0.7.2-beta.1",
   "builders": {
     "docs": "0.x",
     "messages": "1.x",

--- a/manifest.json
+++ b/manifest.json
@@ -1,7 +1,7 @@
 {
   "vendor": "vtex",
   "name": "checkout-shipping",
-  "version": "0.7.1",
+  "version": "0.7.2-beta.0",
   "builders": {
     "docs": "0.x",
     "messages": "1.x",

--- a/manifest.json
+++ b/manifest.json
@@ -9,10 +9,11 @@
   },
   "dependencies": {
     "vtex.address-context": "0.x",
-    "vtex.country-data-settings": "0.x",
     "vtex.checkout-components": "0.x",
     "vtex.checkout-container": "0.x",
     "vtex.checkout-graphql": "0.x",
+    "vtex.checkout-resources": "0.x",
+    "vtex.country-data-settings": "0.x",
     "vtex.format-currency": "0.x",
     "vtex.formatted-price": "0.x",
     "vtex.order-manager": "0.x",
@@ -20,8 +21,7 @@
     "vtex.place-components": "0.x",
     "vtex.places-graphql": "0.x",
     "vtex.shipping-estimate-translator": "2.x",
-    "vtex.styleguide": "9.x",
-    "vtex.apps-graphql": "3.x"
+    "vtex.styleguide": "9.x"
   },
   "$schema": "https://raw.githubusercontent.com/vtex/node-vtex-api/master/gen/manifest.schema"
 }

--- a/react/AddressSummary.tsx
+++ b/react/AddressSummary.tsx
@@ -3,6 +3,7 @@ import { PlaceDetails } from 'vtex.place-components'
 import { AddressContext } from 'vtex.address-context'
 import { OrderShipping } from 'vtex.order-shipping'
 import { OrderForm } from 'vtex.order-manager'
+import { Loading } from 'vtex.render-runtime'
 
 import useAddressRules from './useAddressRules'
 
@@ -44,11 +45,15 @@ const AddressSummaryWithAddress: React.VFC = () => {
 
   const addressRules = useAddressRules()
 
+  if (selectedAddress != null && addressRules == null) {
+    return <Loading />
+  }
+
   return (
     <AddressContext.AddressContextProvider
       address={selectedAddress!}
       countries={countries}
-      rules={addressRules}
+      rules={addressRules ?? {}}
     >
       <AddressSummary />
     </AddressContext.AddressContextProvider>

--- a/react/NewAddressForm.tsx
+++ b/react/NewAddressForm.tsx
@@ -1,5 +1,4 @@
-import React, { useEffect } from 'react'
-import { useQuery } from 'react-apollo'
+import React from 'react'
 import {
   DeviceCoordinates,
   LocationInput,
@@ -7,12 +6,11 @@ import {
   LocationSearch,
 } from 'vtex.place-components'
 import type { Address } from 'vtex.places-graphql'
-import type { Query, QueryInstalledAppArgs } from 'vtex.apps-graphql'
 import { FormattedMessage } from 'react-intl'
 import { ListGroup } from 'vtex.checkout-components'
-import { Link } from 'vtex.render-runtime'
+import { Loading } from 'vtex.render-runtime'
+import { useGeolocationEnabled } from 'vtex.checkout-resources'
 
-import installedApp from './graphql/installedApp.gql'
 import ShippingHeader from './ShippingHeader'
 import { ShippingOptionPreview } from './ShippingOption'
 import ShippingEditError from './components/ShippingEditError'
@@ -36,18 +34,11 @@ const NewAddressForm: React.FC<Props> = ({
   hasError,
   hasAvailableAddresses,
 }) => {
-  const { data, error } = useQuery<Query, QueryInstalledAppArgs>(installedApp, {
-    ssr: false,
-    variables: {
-      slug: 'vtex.geolocation-graphql-interface',
-    },
-  })
+  const [geolocationEnabled, loading] = useGeolocationEnabled()
 
-  useEffect(() => {
-    if (error) {
-      console.error(error)
-    }
-  }, [error])
+  if (loading) {
+    return <Loading />
+  }
 
   if (hasError) {
     return (
@@ -84,7 +75,7 @@ const NewAddressForm: React.FC<Props> = ({
 
       <LocationCountry className="w-100 mw6 mt6" />
 
-      {data?.installedApp?.source === 'none' ? (
+      {!geolocationEnabled ? (
         <div className="mt6 w-100 mw5">
           <LocationInput onSuccess={onAddressCreated} variation="primary" />
         </div>

--- a/react/ShippingForm.tsx
+++ b/react/ShippingForm.tsx
@@ -5,6 +5,7 @@ import { OrderShipping } from 'vtex.order-shipping'
 import { AddressContext } from 'vtex.address-context'
 import { Button } from 'vtex.styleguide'
 import { FormattedMessage } from 'react-intl'
+import { Loading } from 'vtex.render-runtime'
 
 import NewAddressForm from './NewAddressForm'
 import AddressList from './components/AddressList'
@@ -151,6 +152,10 @@ const ShippingFormWithAddress: React.FC = () => {
   const { selectedAddress, countries } = useOrderShipping()
 
   const addressRules = useAddressRules()
+
+  if (addressRules == null) {
+    return <Loading />
+  }
 
   return (
     <AddressContext.AddressContextProvider

--- a/react/graphql/installedApp.gql
+++ b/react/graphql/installedApp.gql
@@ -1,5 +1,0 @@
-query installedApp($slug: String!) {
-  installedApp(slug: $slug) {
-    source
-  }
-}

--- a/react/package.json
+++ b/react/package.json
@@ -9,7 +9,7 @@
     "@types/node": "^12.12.31",
     "@types/react": "^16.9.26",
     "@types/react-router": "^5.1.11",
-    "vtex.address-context": "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.address-context@0.6.1/public/@types/vtex.address-context",
+    "vtex.address-context": "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.address-context@0.6.2/public/@types/vtex.address-context",
     "vtex.checkout-components": "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.checkout-components@0.5.1/public/@types/vtex.checkout-components",
     "vtex.checkout-container": "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.checkout-container@0.7.0/public/@types/vtex.checkout-container",
     "vtex.checkout-graphql": "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.checkout-graphql@0.56.1/public/@types/vtex.checkout-graphql",

--- a/react/package.json
+++ b/react/package.json
@@ -9,11 +9,11 @@
     "@types/node": "^12.12.31",
     "@types/react": "^16.9.26",
     "@types/react-router": "^5.1.11",
-    "vtex.address-context": "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.address-context@0.5.0/public/@types/vtex.address-context",
-    "vtex.apps-graphql": "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.apps-graphql@3.9.1/public/@types/vtex.apps-graphql",
+    "vtex.address-context": "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.address-context@0.6.1/public/@types/vtex.address-context",
     "vtex.checkout-components": "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.checkout-components@0.5.1/public/@types/vtex.checkout-components",
     "vtex.checkout-container": "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.checkout-container@0.7.0/public/@types/vtex.checkout-container",
     "vtex.checkout-graphql": "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.checkout-graphql@0.56.1/public/@types/vtex.checkout-graphql",
+    "vtex.checkout-resources": "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.checkout-resources@0.42.0/public/@types/vtex.checkout-resources",
     "vtex.country-data-settings": "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.country-data-settings@0.3.0/public/@types/vtex.country-data-settings",
     "vtex.format-currency": "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.format-currency@0.3.0/public/@types/vtex.format-currency",
     "vtex.formatted-price": "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.formatted-price@0.4.0/public/@types/vtex.formatted-price",
@@ -23,7 +23,7 @@
     "vtex.places-graphql": "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.places-graphql@0.4.0/public/@types/vtex.places-graphql",
     "vtex.render-runtime": "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.render-runtime@8.126.11/public/@types/vtex.render-runtime",
     "vtex.shipping-estimate-translator": "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.shipping-estimate-translator@2.2.2/public/@types/vtex.shipping-estimate-translator",
-    "vtex.styleguide": "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.styleguide@9.135.1/public/@types/vtex.styleguide"
+    "vtex.styleguide": "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.styleguide@9.135.3/public/@types/vtex.styleguide"
   },
   "dependencies": {
     "@vtex/estimate-calculator": "^1.1.0",

--- a/react/typings/vtex.styleguide.d.ts
+++ b/react/typings/vtex.styleguide.d.ts
@@ -18,4 +18,8 @@ declare module 'vtex.styleguide' {
   const Input: React.FC<any>
 
   const Alert: React.FC<any>
+
+  const Modal: React.FC<any>
+
+  const Divider: React.FC<any>
 }

--- a/react/yarn.lock
+++ b/react/yarn.lock
@@ -338,9 +338,9 @@ use-subscription@^1.3.0:
   dependencies:
     object-assign "^4.1.1"
 
-"vtex.address-context@http://vtex.vtexassets.com/_v/public/typings/v1/vtex.address-context@0.6.1/public/@types/vtex.address-context":
-  version "0.6.1"
-  resolved "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.address-context@0.6.1/public/@types/vtex.address-context#7d636645e335353fa277f52e3f808e4f2d01462b"
+"vtex.address-context@http://vtex.vtexassets.com/_v/public/typings/v1/vtex.address-context@0.6.2/public/@types/vtex.address-context":
+  version "0.6.2"
+  resolved "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.address-context@0.6.2/public/@types/vtex.address-context#f204028dd8a15f4ea0bfe28126684fec34758774"
 
 "vtex.checkout-components@http://vtex.vtexassets.com/_v/public/typings/v1/vtex.checkout-components@0.5.1/public/@types/vtex.checkout-components":
   version "0.5.1"

--- a/react/yarn.lock
+++ b/react/yarn.lock
@@ -156,9 +156,9 @@
     tslib "^1.9.3"
 
 "@xstate/react@^1.2.2":
-  version "1.2.2"
-  resolved "https://registry.yarnpkg.com/@xstate/react/-/react-1.2.2.tgz#54d32034d40384782ee11145bbbb31b841a5a464"
-  integrity sha512-pXcUtts6EaEUmquzpMZ2yhAZZLAFYxKVaaHnQ8MPWpGuby0B5QMch17Ij59+LGQACQTSE0nDqXrvvBQId6m8qQ==
+  version "1.3.1"
+  resolved "https://registry.yarnpkg.com/@xstate/react/-/react-1.3.1.tgz#5794e1c7d2bc70759b5dc2c9ccc9ddaa6e68e98a"
+  integrity sha512-wgAHr4tWVQQwH6dIQTcZQYGLXiK9V8gMqMxOWyiLQzoKchqXFfb0LlCcw0FAc4jmpuGHSFSk6fAXjEpFpV+Jxw==
   dependencies:
     use-isomorphic-layout-effect "^1.0.0"
     use-subscription "^1.3.0"
@@ -338,13 +338,9 @@ use-subscription@^1.3.0:
   dependencies:
     object-assign "^4.1.1"
 
-"vtex.address-context@http://vtex.vtexassets.com/_v/public/typings/v1/vtex.address-context@0.5.0/public/@types/vtex.address-context":
-  version "0.5.0"
-  resolved "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.address-context@0.5.0/public/@types/vtex.address-context#3f984bc73fba901d1c7dbdcebea8d29c7bc450e9"
-
-"vtex.apps-graphql@http://vtex.vtexassets.com/_v/public/typings/v1/vtex.apps-graphql@3.9.1/public/@types/vtex.apps-graphql":
-  version "3.9.1"
-  resolved "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.apps-graphql@3.9.1/public/@types/vtex.apps-graphql#8fd451e4432bb49436eeca000a02ef03f9ba4079"
+"vtex.address-context@http://vtex.vtexassets.com/_v/public/typings/v1/vtex.address-context@0.6.1/public/@types/vtex.address-context":
+  version "0.6.1"
+  resolved "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.address-context@0.6.1/public/@types/vtex.address-context#7d636645e335353fa277f52e3f808e4f2d01462b"
 
 "vtex.checkout-components@http://vtex.vtexassets.com/_v/public/typings/v1/vtex.checkout-components@0.5.1/public/@types/vtex.checkout-components":
   version "0.5.1"
@@ -357,6 +353,10 @@ use-subscription@^1.3.0:
 "vtex.checkout-graphql@http://vtex.vtexassets.com/_v/public/typings/v1/vtex.checkout-graphql@0.56.1/public/@types/vtex.checkout-graphql":
   version "0.56.1"
   resolved "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.checkout-graphql@0.56.1/public/@types/vtex.checkout-graphql#c1153ec5faf232f92abfe495f867019bfb7d510f"
+
+"vtex.checkout-resources@http://vtex.vtexassets.com/_v/public/typings/v1/vtex.checkout-resources@0.42.0/public/@types/vtex.checkout-resources":
+  version "0.42.0"
+  resolved "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.checkout-resources@0.42.0/public/@types/vtex.checkout-resources#96b168e17fe063fc20ba201b027985995c3d37f7"
 
 "vtex.country-data-settings@http://vtex.vtexassets.com/_v/public/typings/v1/vtex.country-data-settings@0.3.0/public/@types/vtex.country-data-settings":
   version "0.3.0"
@@ -394,11 +394,11 @@ use-subscription@^1.3.0:
   version "2.2.2"
   resolved "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.shipping-estimate-translator@2.2.2/public/@types/vtex.shipping-estimate-translator#0daa482f261e7c40a06c27be07e9e5b9d70cf063"
 
-"vtex.styleguide@http://vtex.vtexassets.com/_v/public/typings/v1/vtex.styleguide@9.135.1/public/@types/vtex.styleguide":
-  version "9.135.1"
-  resolved "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.styleguide@9.135.1/public/@types/vtex.styleguide#ed8d203eff74ed072b6e2f6ddb66d0c92b797ade"
+"vtex.styleguide@http://vtex.vtexassets.com/_v/public/typings/v1/vtex.styleguide@9.135.3/public/@types/vtex.styleguide":
+  version "9.135.3"
+  resolved "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.styleguide@9.135.3/public/@types/vtex.styleguide#744a8674d69a56594de969da36b263f94c9de66f"
 
 xstate@^4.16.0:
-  version "4.16.0"
-  resolved "https://registry.yarnpkg.com/xstate/-/xstate-4.16.0.tgz#e434d0558c0f9a7e9212802834992a6c2f47bca6"
-  integrity sha512-2k/49QYLdzG6Ye1JQWYFuPdU6dnRqHXcuFLxuORiuel04GjApSPct7wp2SOz9RAlNME5EkzclRKw1fHm5yejuA==
+  version "4.16.2"
+  resolved "https://registry.yarnpkg.com/xstate/-/xstate-4.16.2.tgz#d6b973b1253b8c85f50f68601837287d59d4bf34"
+  integrity sha512-EY39NNZnwM4tRYNmQAi1c2qHuZ1lJmuDpEo1jxiRcfS+1jPtKRAjGRLNx3fYKcK0ohW6mL41Wze3mdCF0SqavA==


### PR DESCRIPTION
#### What problem is this solving?

Adds a loading state to the geolocation input in case the query is still loading (avoid flicker of input changing from geolocation to postal code). Also uses the hook from `checkout-resources` instead of querying the source directly.

#### How should this be manually tested?

[Workspace](https://checkoutio.myvtexprod.com/?workspace=geoload).

You should be able to see the loading state on the shipping step, which replaces the time for the input flicker.

#### Checklist/Reminders

- [ ] Updated `README.md`.
- [x] Updated `CHANGELOG.md`.
- [ ] Linked this PR to a Jira story (if applicable).
- [ ] Updated/created tests (important for bug fixes).
- [ ] Deleted the workspace after merging this PR (if applicable).

#### Screenshots or example usage

#### Type of changes

<!--- Add a ✔️ where applicable -->
✔️ | Type of Change
---|---
✔️ | Bug fix <!-- a non-breaking change which fixes an issue -->
_ | New feature <!-- a non-breaking change which adds functionality -->
_ | Breaking change <!-- fix or feature that would cause existing functionality to change -->
_ | Technical improvements <!-- chores, refactors and overall reduction of technical debt -->
