### PR TITLE
Update items unavailability message on alert

### DIFF
--- a/messages/pt.json
+++ b/messages/pt.json
@@ -11,7 +11,7 @@
   "store/checkout.shipping.receiverLabel": "Destinatário",
   "store/checkout.shipping.shippingOptionsForAddressLabel": "Opções de entrega para",
   "store/checkout.shipping.continue": "Continuar",
-  "store/checkout.shipping.emptyDeliveryOptionsAlert": "Não há opções de entrega disponíveis.",
+  "store/checkout.shipping.emptyDeliveryOptionsAlert": "Não há opções de entrega disponíveis para a sua localidade.",
   "store/checkout.shipping.changeAddressLabel": "alterar",
   "store/checkout.shipping.seeDetails": "Ver detalhes",
   "store/checkout.shipping.distance": "{distanceValue}km de distância",


### PR DESCRIPTION
This commit perform a small change in the items unavailability message displayed on the alert component. This was done in line with what was projected by the design team.

#### What problem is this solving?

This adapts the message to the designed project.

#### How should this be manually tested?

This was performed directly in the messages file. To check where the message will be displayed, go through the following steps:
1. Proceed to shipping step
2. Input ZIP code "00000-000"
3. Check the message displayed on the alert component.

#### Checklist/Reminders

- [ ] Updated `README.md`.
- [ ] Updated `CHANGELOG.md`.
- [ ] Linked this PR to a Jira story (if applicable).
- [ ] Updated/created tests (important for bug fixes).
- [ ] Deleted the workspace after merging this PR (if applicable).

#### Screenshots or example usage

#### Type of changes

<!--- Add a ✔️ where applicable -->
✔️ | Type of Change
---|---
_ | Bug fix <!-- a non-breaking change which fixes an issue -->
✔️ | New feature <!-- a non-breaking change which adds functionality -->
_ | Breaking change <!-- fix or feature that would cause existing functionality to change -->
_ | Technical improvements <!-- chores, refactors and overall reduction of technical debt -->

#### Notes

<!-- Put any relevant information that doesn't fit in the other sections here. -->
